### PR TITLE
YUM support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -161,8 +161,22 @@ Install_Pacman() {
 }
 #--------------------------------------------------------------------
 Install_Yum() {
-  echo "Yum package install not implemented yet.  Aborting."
-  exit 2
+  echo "Preparing to Install RPM packages..."
+  sleep 5s
+  sudo yum update
+  echo
+  echo "Installing dependencies"
+  sleep 2s
+  sudo yum -y install unzip
+  echo
+  echo "Installing Dnsmasq"
+  sleep 2s
+  sudo yum -y install dnsmasq
+  echo
+  echo "Installing Lighttpd and PHP5"
+  sleep 2s
+  sudo yum -y install lighttpd php
+  echo
 }
 #--------------------------------------------------------------------
 Install_Zypper() {


### PR DESCRIPTION
Add support for the YUM/DNF package manager.
* NOTE: Only tested on Fedora Server 23

This doesn't fix installation on YUM (Fedora) distributions it only allows the installation of the required packages.
The installer will still fail when trying to find /var/www/lighttpd/NoTrack/conf/dnsmasq.conf stating it is missing despite the file existing at that location.