### PR TITLE
Add a few more advertising sites

### DIFF
--- a/trackers.txt
+++ b/trackers.txt
@@ -33,6 +33,7 @@
 4nabs.com
 51yes.com
 51.la
+52tyd.com #Advertising
 5gl1x9qc.com
 5min.com
 6000088.com #HelloWorld
@@ -441,6 +442,7 @@ blackholemyemail.com #Campaign Monitor Pty
 blinkx.com
 blocwhite7.com #Lead Forensics
 blogherads.com
+bolimubei.com #Advertising
 bosctrl32.com #Lead Forensics
 bluebillywig.com
 bluekai.com #Oracle
@@ -558,6 +560,7 @@ cashbackwindow.com #Digital Window
 cashforfundraising.com #Digital Window
 cashlantis.com
 ccmp.eu #Experian
+cctyly.com #Advertising
 cdngc.net
 cdn-net.com
 cedexis.com
@@ -1035,6 +1038,7 @@ evelinecourt.net #Ad Web
 eventcapture03.com #Lead Forensics
 eventcapture06.com #Lead Forensics
 evergage.com
+ever-lohas.com #Advetising
 ever-track-51.com #Lead Forensics
 everestjs.net
 everesttech.net
@@ -1388,6 +1392,7 @@ kastatic.com
 kau.li
 keen.io #Keen IO (analytics)
 kestrelfm.net #Ad Web
+keytui.com #Advertising
 keyweego.com #Keywee
 keywords.com #Microsoft
 kiespr.com #TMRG
@@ -1519,6 +1524,7 @@ mediamond.it #Mediamond
 mediaplex.com
 mediavoice.com
 member-hsbc-group.com #HSBC
+mengmob.com #Advertising
 merchenta.com
 messages1.com #IBM Silverpop
 messages2.com #IBM Silverpop
@@ -9602,6 +9608,7 @@ q4websystems.com
 qeryz.com
 qingcdn.com #Advertising
 qmerce.com
+mp.weixin.qq.com #Advetising, altough TLD name qq.com seems a legit search engine.
 qservz.com
 qsubmit.com
 qualtrics.com
@@ -9662,6 +9669,7 @@ relatedweboffers.com #RevenueHits
 relestar.com
 relevancegraph.mobi #Millennial Media
 relevantknowledge.com #TMRG
+reliancevalve.com #Advertising
 rename.com #Digital Window
 rename.net #Digital Window
 reportwindow.com #Digital Window
@@ -9839,6 +9847,7 @@ shop2market.com
 shoppingshadow.com #ebay
 shopwindow.com #Digital Window
 shopwindowforum.com #Digital Window
+shuhenelk.com #Advertising
 shrfbdg004.com #Lead Forensics
 shwired.com #TMRG
 shwired.net #TMRG
@@ -10091,6 +10100,7 @@ typekit.net #Belongs to Adobe, may or may not be a tracker
 tynt.com
 tyskyt.com #YieldBot
 tyskyt.net #YieldBot
+tzcccm.com #Advertising
 #U-U-U-U-U-U-U-U-U-U-U-U-U-U-U-U-U-U-U-U
 uadx.com
 udmserve.net
@@ -10284,6 +10294,7 @@ xct33.net #IBM Silverpop
 xg4ken.com
 xibei70.com #Adverising
 xiti.com
+xixiwan.net #Advertising
 pubs.xl.pt #Adverts of the XL's news papers (do not remove top domain name)
 #Y-Y-Y-Y-Y-Y-Y-Y-Y-Y-Y-Y-Y-Y-Y-Y-Y-Y-Y-Y
 yadro.ru
@@ -10299,6 +10310,7 @@ yieldmanager.com
 yieldmo.com #Yieldmo
 yieldoptimizer.com
 yieldpartners.com
+yijia2009.com  #Advetising
 yjtag.jp
 yldbt.com #YeildBot
 yldmgrimg.net #Yahoo

--- a/trackers.txt
+++ b/trackers.txt
@@ -790,6 +790,7 @@ crsspxl.com #Cross Pixel
 crtracklink.com
 crwdcntrl.net
 cspbuilder.info
+cstoa.com
 ctasnet.com
 ctd001.net #Experian
 ctd002.net #Experian


### PR DESCRIPTION
A batch of chinses advertising sites, mainly directed to mobile.

I also had 3 more domains which i am unsure * if its adverts or tracking or something else "legit" like the baidu's opensug , don't know if you know about them or want to investigate @quidsup 

*(i have my doubts becouse some advertisers like to have js that ads the adverts with js, after the page has loaded)
```
http://js.cctyly.com/fc-2132-1.js
http://njs.reliancevalve.com/fixedc/i.php?z=44
http://www.baidu.com/js/opensug.js
```

**Edit:** cctyly.com is what i expected [to see what it was i had to fake a mobile UA and in the js code i saw what it does it redirects (popup?) to the site advertised also a "shock" one], therefor i've added it to the list. The other 2 still an unknown to me baidu i can see the js code but idk what is its use yet, the other don't know what is either (needs a mobile UA too)