### PR TITLE
Add FanBoy's Portugal/Spain list

### DIFF
--- a/admin/config.php
+++ b/admin/config.php
@@ -392,7 +392,8 @@ function DisplayBlockLists() {
   DrawBlockListRow('bl_chneasy', 'CHN EasyList', 'EasyList China (中文)‎ <a href="http://abpchina.org/forum/forum.php">(abpchina.org)</a>');
   
   DrawBlockListRow('bl_deueasy', 'DEU EasyList', 'EasyList Germany (Deutsch) <a href="https://forums.lanik.us/viewforum.php?f=90">(forums.lanik.us)</a>');
-  DrawBlockListRow('bl_dnkeasy', 'DNK EasyList', 'Schacks Adblock Plus liste‎ (Danmark) <a href="https://henrik.schack.dk/adblock/">(henrik.schack.dk)</a>');
+  DrawBlockListRow('bl_dnkeasy', 'DNK EasyList', 'Schacks Adblock Plus liste‎ (Danmark) <a href="https://henrik.schack.dk/adblock/">(henrik.schack.dk)</a>');  
+  DrawBlockListRow('bl_fblatin', 'Latin EasyList', 'Spanish/Portuguese Adblock List <a href="https://www.fanboy.co.nz/regional.html">(fanboy.co.nz)</a>');
   
   DrawBlockListRow('bl_ruseasy', 'RUS EasyList', 'Russia RuAdList+EasyList (Россия Фильтр) <a href="https://forums.lanik.us/viewforum.php?f=102">(forums.lanik.us)</a>');
   echo '</table></div></div>'.PHP_EOL;
@@ -884,6 +885,7 @@ function UpdateBlockListConfig() {
   $Config['bl_deueasy'] = Filter_Config('bl_deueasy');
   $Config['bl_dnkeasy'] = Filter_Config('bl_dnkeasy');
   $Config['bl_ruseasy'] = Filter_Config('bl_ruseasy');
+  $Config['bl_fblatin'] = Filter_Config('bl_fblatin');
   
   if (isset($_POST['bl_custom'])) {    
     $CustomStr = preg_replace('#\s+#',',',trim($_POST['bl_custom'])); //Split array

--- a/admin/include/global-functions.php
+++ b/admin/include/global-functions.php
@@ -349,6 +349,10 @@ function LoadConfigFile() {
             case 'bl_ruseasy':
               $Config['bl_ruseasy'] = Filter_Int_Value($SplitLine[1], 0, 1, 0);
               break;
+            case 'BlockList_FBLatin':
+            case 'bl_fblatin':
+              $Config['bl_fblatin'] = Filter_Int_Value($SplitLine[1], 0, 1, 0);
+              break;
           }
         }
       }

--- a/admin/include/global-vars.php
+++ b/admin/include/global-vars.php
@@ -61,6 +61,7 @@ $DefaultConfig = array(
   'bl_deueasy' => 0,
   'bl_dnkeasy' => 0,
   'bl_ruseasy' => 0,
+  'bl_fblatin' => 0,
   'LatestVersion' => $Version  
 );
 

--- a/notrack.sh
+++ b/notrack.sh
@@ -42,6 +42,7 @@ Config[bl_chneasy]=0                      #China
 Config[bl_deueasy]=0                      #Germany
 Config[bl_dnkeasy]=0                      #Denmark
 Config[bl_ruseasy]=0                      #Russia
+Config[bl_fblatin]=0                      #Portugal/Spain (Latin Countries)
 
 #Leave these Settings alone------------------------------------------
 Version="0.7.16"
@@ -83,6 +84,7 @@ URLList[chneasy]="https://easylist-downloads.adblockplus.org/easylistchina.txt"
 URLList[deueasy]="https://easylist-downloads.adblockplus.org/easylistgermany.txt"
 URLList[dnkeasy]="https://adblock.dk/block.csv"
 URLList[ruseasy]="https://easylist-downloads.adblockplus.org/ruadlist+easylist.txt"
+URLList[fblatin]="https://www.fanboy.co.nz/fanboy-espanol.txt"
 
 #Global Variables----------------------------------------------------
 FileTime=0                                       #Return value from Get_FileTime
@@ -252,7 +254,8 @@ function Read_Config_File() {
           bl_chneasy) Config[bl_chneasy]="$Value";;
           bl_deueasy) Config[bl_deueasy]="$Value";;
           bl_dnkeasy) Config[bl_dnkeasy]="$Value";;
-          bl_ruseasy) Config[bl_ruseasy]="$Value";;          
+          bl_ruseasy) Config[bl_ruseasy]="$Value";;   
+          bl_fblatin) Config[bl_fblatin]="$Value";;         
         esac            
       fi
     done < $ConfigFile
@@ -1128,8 +1131,9 @@ GetList "winhelp2002" "unix"
 GetList "areasy" "easylist"
 GetList "chneasy" "easylist"
 GetList "deueasy" "easylist"
-GetList "dnkeasy" "easylist"
+GetList "dnkeasy" "easylist" 
 GetList "ruseasy" "easylist"
+GetList "fblatin" "easylist"
  
 Get_Custom                                       #Process Custom Block lists
 


### PR DESCRIPTION
This PR adds FanBoy's Portugal/Spain list, i named the var as fblatin as it covers many , and probably most latin ads , if you have a better name for the var i'm open for suggestions and can change it.