### PR TITLE
NoTrack admin page wrong error info

### DIFF
--- a/admin/include/global-vars.php
+++ b/admin/include/global-vars.php
@@ -177,7 +177,7 @@ $WHOISLIST = array(
 
 
 if (!extension_loaded('memcache')) {
-  die('NoTrack requires memcached and php-memcache to be installed');
+  die('NoTrack requires memcached, php-memcache and php-memcached to be installed');
 }
 
 $mem = new Memcache;                             //Initiate Memcache


### PR DESCRIPTION
I had an error on the login page where it said it needs php-memcache. I checked for modules (`php -m | grep memcache`) and installed packages (for both `memcached` and `php-memcache` ) and they both showed memcache as installed. However I then installed `php-memcached`(**d** at the end) and that fixed the error.

I didn't look into the source code to find if NoTrack really uses php-memcache but I left it in the error message.