### PR TITLE
Debian improvements

### DIFF
--- a/install-debian.sh
+++ b/install-debian.sh
@@ -514,7 +514,7 @@ function install_deb() {
   echo
   echo "Installing PHP"
   sleep 2s
-  sudo apt -y install memcached php-memcache php php-fpm php-curl php-mysql
+  sudo apt -y install memcached php-memcache php-memcached php php-fpm php-curl php-mysql
   echo
   echo "Installing Python3"
   sleep 2s

--- a/src/config.py
+++ b/src/config.py
@@ -231,7 +231,7 @@ class NoTrackConfig:
 
         #If dhcp is disabled, then delete dhcp.conf file
         if self.__config['dhcp_enabled'] == '0':
-            delete_file(folders.dhcpconf)
+            delete(folders.dhcpconf)
             return
 
         print('Saving dhcp.conf')

--- a/src/folders.py
+++ b/src/folders.py
@@ -64,6 +64,6 @@ if os.name == 'posix':
     #Output Config Files
     localhosts = f'{etcdir}/localhosts.list'
     dhcpconf = f'{etcdir}/dnsmasq.d/dhcp.conf'
-    serverconf = f'{etcdir}/dnsmasq.d/server.conf'
+    serverconf = f'{etcdir}/dnsmasq.d/servers.conf'
 
 

--- a/src/notrackd.py
+++ b/src/notrackd.py
@@ -193,6 +193,7 @@ def check_config_files():
         blocklist_update()
 
     elif filechanged == 'server.php':                      #Server Config
+        blocklist_update()
         restart_dns()
 
 


### PR DESCRIPTION
I began using noTrack a few days ago on my new debian buster based linux home router and noticed some things which were `bugs` in my opinion.

- I used the `install-debian.sh` as `root` and had to install `php-memcached` before I could use the web interface
- I do not use the `DHCP` server functionality and noticed a stack-trace because of a misnamed function
- Noticed, that the `dnsmasq` configuration for the upstream DNS servers was named differently after installation and after updates
- The IP address configured via the web interface was not used in the `notrack.list` for `dnsmasq`

Maybe you could incorporate these fixes in your next release?